### PR TITLE
WIP: add Avro schema

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
              "name": "moltype",
              "symbols": ["DNA", "protein", "hp", "dayhoff"] }
            },
-           { "name":"hashes",
+           { "name":"mins",
              "type": {
                 "type": "array",  
                  "items":{

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,47 +39,55 @@ fn main() -> Result<()> {
     // Avro
     let sig_schema = r#"
 {
-    "name": "SourmashSignature",
+    "name": "Signature",
     "type":"record",
     "fields":[
+       { "name": "class", "type": "string"},
+       { "name": "email", "type": "string"},
+       { "name": "hash_function", "type": "string"},
        { "name": "filename", "type": "string"},
        { "name": "name", "type": "string"},
-       { "name": "minhash",
+       { "name": "license", "type": "string"},
+
+       { "name": "signatures",
          "type": {
-         "type": "record",
-         "name": "MinHash",
-         "fields":[
-           { "name": "num", "type": "int" },
-           { "name": "scaled", "type": "int" },
-           { "name": "ksize", "type": "int" },
-           { "name": "molecule", "type": {
-             "type": "enum",
-             "name": "moltype",
-             "symbols": ["DNA", "protein", "hp", "dayhoff"] }
-           },
-           { "name":"mins",
-             "type": {
-                "type": "array",  
-                 "items":{
-                     "name":"hash",
-                     "type":"fixed",
-                     "size": 8
-                 }
-              }
-           },
-           { "name":"abunds",
-             "type": {
-                 "type": "array",  
-                 "items":{
+            "type": "array",
+            "items": {
+
+           "name": "MinHash",
+           "type": "record",
+           "fields":[
+             { "name": "num", "type": "int" },
+             { "name": "ksize", "type": "int" },
+             { "name": "seed", "type": "int" },
+             { "name": "max_hash", "type": { "name": "ulong", "type": "fixed", "size": 8 } },
+             { "name":"mins",
+               "type": {
+                  "type": "array",  
+                   "items":{
+                       "name":"hash",
+                       "type":"fixed",
+                       "size": 8
+                   }
+                }
+             },
+             { "name": "md5sum", "type": "string" },
+             { "name":"abunds",
+               "type": {
+                  "type": "array",  
+                  "items":{
                      "name":"abund",
                      "type":"int"
-                 }
-             }
-           }
-         ]
+                   }
+                }
+             },
+           { "name": "molecule", "type": "string" }
+           ]
+         }
        }
        }
-    ]
+ 
+       ]
 }
 "#;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,11 +37,38 @@ fn main() -> Result<()> {
     std::fs::create_dir_all(&outdir)?;
 
     // Avro
-    /*
     let minhash_schema = r#"{
+    "name": "MinHash",
+    "type":"record",
+    "fields":[
+        { "name": "scaled", "type": "int" },
+        { "name": "ksize", "type": "int" },
+        { "name": "molecule", "type": {
+          "type": "enum",
+          "name": "moltype",
+          "symbols": ["DNA", "protein", "hp", "dayhoff"] }
+        },
+        { "name":"hashes",
+          "type": {
+             "type": "array",  
+              "items":{
+                  "name":"hash",
+                   "type":"fixed",
+                   "size": 8
+              }
+           }
+        }
+    ]
     }"#;
 
     let sig_schema = r#"{
+    "name": "SourmashSignature",
+    "type":"record",
+    "fields":[
+       { "name": "filename", "type": "string"},
+       { "name": "name", "type": "string"},
+       { "name": "minhash", "type": "MinHash" }
+     ]
     }"#;
 
     let schema = avro_rs::Schema::parse_list(&[sig_schema, minhash_schema])?;
@@ -51,7 +78,6 @@ fn main() -> Result<()> {
     writer.append_ser(&signature)?;
     let encoded = writer.into_inner()?;
     dbg!(encoded);
-    */
 
     info!("flexbuffer: encoding");
     //let mut s = flexbuffers::FlexbufferSerializer::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
        { "name": "filename", "type": "string"},
        { "name": "name", "type": "string"},
        { "name": "license", "type": "string"},
+       { "name": "version", "type": "float" },
 
        { "name": "signatures",
          "type": {
@@ -61,6 +62,7 @@ fn main() -> Result<()> {
              { "name": "ksize", "type": "int" },
              { "name": "seed", "type": "int" },
              { "name": "max_hash", "type": { "name": "ulong", "type": "fixed", "size": 8 } },
+             { "name": "md5sum", "type": "string" },
              { "name":"mins",
                "type": {
                   "type": "array",  
@@ -71,7 +73,6 @@ fn main() -> Result<()> {
                    }
                 }
              },
-             { "name": "md5sum", "type": "string" },
              { "name":"abunds",
                "type": {
                   "type": "array",  
@@ -80,8 +81,7 @@ fn main() -> Result<()> {
                      "type":"int"
                    }
                 }
-             },
-           { "name": "molecule", "type": "string" }
+             }
            ]
          }
        }
@@ -95,9 +95,11 @@ fn main() -> Result<()> {
 
     let mut writer = avro_rs::Writer::with_codec(&schema[0], Vec::new(), avro_rs::Codec::Deflate);
 
+    info!("avro: encoding");
     writer.append_ser(&signature)?;
     let encoded = writer.into_inner()?;
     dbg!(encoded);
+    info!("avro: done");
 
     info!("flexbuffer: encoding");
     //let mut s = flexbuffers::FlexbufferSerializer::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,41 +37,53 @@ fn main() -> Result<()> {
     std::fs::create_dir_all(&outdir)?;
 
     // Avro
-    let minhash_schema = r#"{
-    "name": "MinHash",
-    "type":"record",
-    "fields":[
-        { "name": "scaled", "type": "int" },
-        { "name": "ksize", "type": "int" },
-        { "name": "molecule", "type": {
-          "type": "enum",
-          "name": "moltype",
-          "symbols": ["DNA", "protein", "hp", "dayhoff"] }
-        },
-        { "name":"hashes",
-          "type": {
-             "type": "array",  
-              "items":{
-                  "name":"hash",
-                   "type":"fixed",
-                   "size": 8
-              }
-           }
-        }
-    ]
-    }"#;
-
-    let sig_schema = r#"{
+    let sig_schema = r#"
+{
     "name": "SourmashSignature",
     "type":"record",
     "fields":[
        { "name": "filename", "type": "string"},
        { "name": "name", "type": "string"},
-       { "name": "minhash", "type": "MinHash" }
-     ]
-    }"#;
+       { "name": "minhash",
+         "type": {
+         "type": "record",
+         "name": "MinHash",
+         "fields":[
+           { "name": "num", "type": "int" },
+           { "name": "scaled", "type": "int" },
+           { "name": "ksize", "type": "int" },
+           { "name": "molecule", "type": {
+             "type": "enum",
+             "name": "moltype",
+             "symbols": ["DNA", "protein", "hp", "dayhoff"] }
+           },
+           { "name":"hashes",
+             "type": {
+                "type": "array",  
+                 "items":{
+                     "name":"hash",
+                     "type":"fixed",
+                     "size": 8
+                 }
+              }
+           },
+           { "name":"abunds",
+             "type": {
+                 "type": "array",  
+                 "items":{
+                     "name":"abund",
+                     "type":"int"
+                 }
+             }
+           }
+         ]
+       }
+       }
+    ]
+}
+"#;
 
-    let schema = avro_rs::Schema::parse_list(&[sig_schema, minhash_schema])?;
+    let schema = avro_rs::Schema::parse_list(&[sig_schema])?;
 
     let mut writer = avro_rs::Writer::with_codec(&schema[0], Vec::new(), avro_rs::Codec::Deflate);
 


### PR DESCRIPTION
This PR adds Apache Avro as an output format.

The schema was copied over from a Python avro reader/writer plugin, [here](https://github.com/sourmash-bio/sourmash_plugin_avro).

The tricky bit was the schema, which is defined [here](https://github.com/sourmash-bio/sourmash_plugin_avro/blob/main/signature.avsc). The good news? It compiles! And, in Python, it seems to work! The bad news - more work needs to be done on the Rust side; when I do:

```
cargo run ../sourmash/podar-ref/1.fa.sig -o xxx
```

I get:
```
Error: Value does not match schema
```